### PR TITLE
Fix Nitro EV formula to account for top jackpot probability

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,17 +127,20 @@
       <label>x1k %
         <input id="ne_p1000" type="number" value="100" min="0" max="100" step="0.1" />
       </label>
+      <label>% TOP-джекпота в пуле
+        <input id="ne_ptop" type="number" value="0" min="0" max="100" step="0.1" />
+      </label>
       <label>RakeBack %
         <input id="ne_rb" type="number" value="0" min="0" max="100" step="0.1" />
       </label>
     </div>
 
     <div class="kpis">
-      <div class="kpi"><b>Profit/игру</b><span id="ne_profitGame">—</span></div>
-      <div class="kpi"><b>PoolEV</b><span id="ne_poolEv">—</span></div>
-      <div class="kpi"><b>Rake</b><span id="ne_rakeTotal">—</span></div>
-      <div class="kpi"><b>RB</b><span id="ne_rbTotal">—</span></div>
-      <div class="kpi"><b>Profit</b><span id="ne_sumProfit">—</span></div>
+      <div class="kpi"><b>EV/игру</b><span id="ne_evGame">—</span></div>
+      <div class="kpi"><b>PoolEV (только EV)</b><span id="ne_poolEv">—</span></div>
+      <div class="kpi"><b>Rake (∑ B · Rake%)</b><span id="ne_rakeTotal">—</span></div>
+      <div class="kpi"><b>Rakeback (Rake · RB%)</b><span id="ne_rbTotal">—</span></div>
+      <div class="kpi"><b>Суммарный профит = EV + RB</b><span id="ne_sumProfit">—</span></div>
     </div>
 
     <details>
@@ -405,6 +408,7 @@
   };
 
   function ne_payBI(m, type){ return (type==='icm') ? [0.8*m,0.12*m,0.08*m] : [m,0,0]; }
+  function ne_topIndex(){ return 0; }
   function ne_euro(n){ return n.toLocaleString('ru-RU',{minimumFractionDigits:2,maximumFractionDigits:2}); }
 
   function calculateNitro(){
@@ -412,16 +416,18 @@
     const CE   = +document.getElementById('ne_ce').value;
     const N    = +document.getElementById('ne_N').value;
     const p100 = Math.max(0, Math.min(100, +document.getElementById('ne_p1000').value));
+    const pTop = Math.max(0, Math.min(100, +document.getElementById('ne_ptop').value));
     const rb   = Math.max(0, Math.min(100, +document.getElementById('ne_rb').value));
     const rakePct = +document.getElementById('rakePct').value / 100;
     const S = 300;
 
     const base = NE_PROBS[B].map(r=>({...r}));
     for(const r of base){ if(r.m===1000) r.p = r.p * (p100/100); }
+    base[ne_topIndex()].p = base[ne_topIndex()].p * (pTop/100);
 
     const sumP = base.reduce((s,r)=>s+r.p,0);
     if(sumP<=0){
-      document.getElementById('ne_profitGame').textContent='—';
+      document.getElementById('ne_evGame').textContent='—';
       document.getElementById('ne_poolEv').textContent='—';
       document.getElementById('ne_rakeTotal').textContent='—';
       document.getElementById('ne_rbTotal').textContent='—';
@@ -450,12 +456,10 @@
 
     const rakePerGame = B * rakePct;
     const rakeTotal   = rakePerGame * N;
-    const rbPerGame   = rakePerGame * (rb/100);
-    const rbTotal     = rbPerGame * N;
-    const profitGame  = EV_game + rbPerGame;
+    const rbTotal     = rakeTotal * (rb/100);
     const sumProfit   = PoolEV + rbTotal;
 
-    document.getElementById('ne_profitGame').textContent = `${ne_euro(profitGame)} €`;
+    document.getElementById('ne_evGame').textContent    = `${ne_euro(EV_game)} €`;
     document.getElementById('ne_poolEv').textContent    = `${ne_euro(PoolEV)} €`;
     document.getElementById('ne_rakeTotal').textContent = `${ne_euro(rakeTotal)} €`;
     document.getElementById('ne_rbTotal').textContent   = `${ne_euro(rbTotal)} €`;
@@ -468,7 +472,7 @@
       `<b>Rake_total = rake_per_game·N</b>, `+
       `<b>Rakeback_total = Rake_total·(RB%)</b>. Итог: <b>Суммарный профит = PoolEV + Rakeback_total</b>.<br>`+
       `Текущие: Win%=${(Win*100).toFixed(2)}%, Coef(2/3)=${(W23*100).toFixed(2)}%, B=${B}€, CE=${CE}, `+
-      `x1000=${p100.toFixed(2)}%, RB%=${rb.toFixed(1)}%.`;
+      `x1000=${p100.toFixed(2)}%, TOP=${pTop.toFixed(2)}%, RB%=${rb.toFixed(1)}%.`;
 
     document.getElementById('ne_diag_avgs').innerHTML =
       `<b>Средние выплаты по пулу (в BI)</b><br>
@@ -481,7 +485,7 @@
   }
 
   // Слушатели для Nitro и общих контролов
-  ['ne_ce','ne_N','ne_p1000','ne_rb'].forEach(id=>{
+  ['ne_ce','ne_N','ne_p1000','ne_ptop','ne_rb'].forEach(id=>{
     const el=document.getElementById(id);
     el.addEventListener('input',calculateNitro);
     el.addEventListener('change',calculateNitro);


### PR DESCRIPTION
## Summary
- adjust Nitro EV calculator to use top-jackpot probability and output EV per game
- show separate EV, rake, rakeback and total profit metrics

## Testing
- `node <<'NODE'
const NE_PROBS={100:[{m:10000,p:4/1e6,type:'icm'},{m:1000,p:20/1e6,type:'icm'},{m:100,p:200/1e6,type:'icm'},{m:50,p:1000/1e6,type:'icm'},{m:10,p:15000/1e6,type:'wta'},{m:5,p:40000/1e6,type:'wta'},{m:4,p:80000/1e6,type:'wta'},{m:3,p:262448/1e6,type:'wta'},{m:2,p:601328/1e6,type:'wta'}]};
function ne_payBI(m,type){return (type==='icm')?[0.8*m,0.12*m,0.08*m]:[m,0,0];}
function ne_topIndex(){return 0;}
function calc(B,CE,N,p100,pTop){const base=NE_PROBS[B].map(r=>({...r}));for(const r of base){if(r.m===1000) r.p=r.p*(p100/100);}base[ne_topIndex()].p=base[ne_topIndex()].p*(pTop/100);const sumP=base.reduce((s,r)=>s+r.p,0);let Avg1=0,Avg2=0,Avg3=0;base.forEach(r=>{const w=r.p/sumP;const[a,b,c]=ne_payBI(r.m,r.type);Avg1+=w*a;Avg2+=w*b;Avg3+=w*c;});const S=300;const Win=(S+CE)/(3*S);const W23=(2*S-CE)/(3*S);const EV_BI=(Win*Avg1+W23*((Avg2+Avg3)/2)-1);const EV_game=EV_BI*B;const PoolEV=EV_game*N;return {EV_BI,EV_game,PoolEV};}
console.log(calc(100,12.8,11394,100,0));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b1b174de3c8331bd7630a9dcfb7c5d